### PR TITLE
Fix README typo, link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Super Sphere! is a minimal action game by Kenneth Reitz, with music, graphics, and programming all done by Kenneth Reitz. 
 
-It is heavily inspired by Super Hexagon, but is designed to be more addictive/repayable.
+It is heavily inspired by Super Hexagon, but is designed to be more addictive/replayable.
 
 ![screenshot](https://d3vv6lp55qjaqc.cloudfront.net/items/0x1b2M0e3t1y0N1G1k0H/Screen%20Shot%202017-07-18%20at%2012.12.40%20PM.png?X-CloudApp-Visitor-Id=82d24e4c359857588fbbc6efe953451c&v=3f728fa9)
 
@@ -18,4 +18,4 @@ Free [builds are available](https://github.com/kennethreitz/super-sphere/release
 
 ## See Also
 
-- [Super Sphere II](https://github.com/kennethreitz/super-sphere)
+- [Super Sphere II](https://github.com/kennethreitz/super-sphere2)


### PR DESCRIPTION
Hi. I noticed a typo, and the link was circular instead of pointing to the second game. Cheers. :black_heart: 